### PR TITLE
Implement message queue which prevents passing the flood limit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 
 - Call add channel from the channel list menu
 - Fix problem with channels having no username
+- Implement MessageQueue from telegram python bot to prevent hitting the flood limit
 
 
 0.1.3 (2019-01-29)

--- a/xenian_channel/bot/commands/channelmanager.py
+++ b/xenian_channel/bot/commands/channelmanager.py
@@ -137,7 +137,7 @@ class ChannelManager(BaseCommand):
         current_message = TgMessage.objects(chat=self.tg_chat, is_current_message=True).first()
 
         if not current_message or kwargs.get('create', False):
-            new_message = self.message.reply_text(*args, **kwargs)
+            new_message = self.message.reply_text(*args, **kwargs).result()
             if current_message:
                 try:
                     self.bot.delete_message(chat_id=self.chat.id, message_id=current_message.message_id)
@@ -647,13 +647,7 @@ class ChannelManager(BaseCommand):
             try:
                 method, include_kwargs, reaction_dict = self.prepare_send_message(stored_message, is_preview=preview)
 
-                # Prevent hitting flood limit
-                if preview:
-                    sleep(1 / 29)  # In private chat the flood limit is at 30 messages / second
-                else:
-                    sleep(60 / 19)  # In groups and channels the limit is at 20 messages / minute
-
-                new_message = method(chat_id=send_to.id, **include_kwargs)
+                new_message = method(chat_id=send_to.id, **include_kwargs, isgroup=not preview)
                 if not preview:
                     new_tg_message = TgMessage(new_message, reactions=reaction_dict)
                     new_tg_message.save()

--- a/xenian_channel/bot/utils/progress_bar.py
+++ b/xenian_channel/bot/utils/progress_bar.py
@@ -138,7 +138,7 @@ class TelegramProgressBar:
                                           bar=self.unloaded_char * self.line_width,
                                           se='\n' + self.se_message if self.se_message else '')
         message = message.format(current=self.current_step, total=self.full_amount, step_size=self.step_size)
-        self.last_message = self.bot.send_message(self.chat_id, message, parse_mode=ParseMode.MARKDOWN)
+        self.last_message = self.bot.send_message(self.chat_id, message, parse_mode=ParseMode.MARKDOWN).result()
         self.started = True
 
     def update(self,
@@ -197,7 +197,7 @@ class TelegramProgressBar:
             except TimedOut:
                 pass
             return
-        self.last_message = self.bot.send_message(self.chat_id, message, parse_mode=ParseMode.MARKDOWN)
+        self.last_message = self.bot.send_message(self.chat_id, message, parse_mode=ParseMode.MARKDOWN).result()
 
     def remove(self):
         """Remove your progressbar from Telegram.


### PR DESCRIPTION
The flood limit for private chats is set slightly lower set then the actual limit. Why this is done can be read here: https://github.com/python-telegram-bot/python-telegram-bot/wiki/Avoiding-flood-limits